### PR TITLE
Add Jest testing setup and extractor test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "jest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",
@@ -124,7 +125,10 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.3",
     "typescript": "^5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/focused-extractor.ts
+++ b/server/focused-extractor.ts
@@ -1,0 +1,67 @@
+import fs from 'fs/promises';
+import { JSDOM } from 'jsdom';
+
+export interface Variant {
+  color: string;
+  size: string;
+}
+
+export interface Feature {
+  key: string;
+  value: string;
+}
+
+export interface ExtractionResult {
+  success: boolean;
+  brand: string;
+  title: string;
+  price: string;
+  images: string[];
+  variants: Variant[];
+  features: Feature[];
+}
+
+export async function extractFromHtml(html: string): Promise<ExtractionResult> {
+  const dom = new JSDOM(html);
+  const scriptEls = Array.from(dom.window.document.querySelectorAll('script[type="application/ld+json"]'));
+  const data = scriptEls
+    .map(el => {
+      try { return JSON.parse(el.textContent || '{}'); } catch { return {}; }
+    })
+    .find(d => d['@type'] === 'ProductGroup');
+
+  if (!data) {
+    return { success: false, brand: '', title: '', price: '', images: [], variants: [], features: [] };
+  }
+
+  const brand = data.brand?.name ?? data.manufacturer ?? '';
+  const title = data.name ?? '';
+  const price = data.offers?.price ?? '';
+  const images: string[] = Array.isArray(data.image?.contentUrl) ? data.image.contentUrl : [];
+
+  const variants: Variant[] = [];
+  if (Array.isArray(data.hasVariant)) {
+    for (const v of data.hasVariant) {
+      const color = v.color ?? '';
+      const sizes = Array.isArray(v.size) ? v.size : [];
+      for (const size of sizes) {
+        variants.push({ color, size });
+      }
+    }
+  }
+
+  const features: Feature[] = [];
+  const additional = data.additionalProperty ?? [];
+  for (const f of additional) {
+    if (f.name && f.unitText) {
+      features.push({ key: f.name, value: f.unitText });
+    }
+  }
+
+  return { success: true, brand, title, price, images, variants, features };
+}
+
+export async function extractFromFile(filePath: string): Promise<ExtractionResult> {
+  const html = await fs.readFile(filePath, 'utf8');
+  return extractFromHtml(html);
+}

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,0 +1,15 @@
+import { extractFromFile } from '../server/focused-extractor';
+
+const htmlPath = 'wamoss_product.html';
+
+test('extracts product data from wamoss_product.html', async () => {
+  const result = await extractFromFile(htmlPath);
+  expect(result.success).toBe(true);
+  expect(result.brand).toBe('wamoss');
+  expect(result.title).toContain('wamoss Salaş Mevsimlik Pileli Klasik Baggy Pantolon');
+  expect(result.price).toBe('399.99');
+  expect(result.images.length).toBeGreaterThan(0);
+  expect(result.images[0]).toMatch(/1_org_zoom.jpg$/);
+  expect(result.variants.length).toBeGreaterThan(0);
+  expect(result.features.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add Jest, ts-jest and @types/jest dev dependencies
- add `test` script to run Jest
- implement a simple HTML extractor in `server/focused-extractor.ts`
- configure Jest
- add a sample test verifying extraction from `wamoss_product.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2ae9c5d4832792fe76b8cbd82723